### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   build-jar:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FarmVivi/discord-bot/security/code-scanning/6](https://github.com/FarmVivi/discord-bot/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
- The `contents: read` permission is needed to check out the repository code.
- The `contents: write` permission is required to upload the JAR file to the GitHub release.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
