### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [ "main" ]
     tags: [ "v*.*.*" ]
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 jobs:
   build-docker-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FarmVivi/discord-bot/security/code-scanning/5](https://github.com/FarmVivi/discord-bot/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` to access the repository's contents.
- `packages: write` to push Docker images to the GitHub Container Registry (GHCR).
- `id-token: write` to authenticate with the registry securely.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
