### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-patch-version.yml
+++ b/.github/workflows/bump-patch-version.yml
@@ -2,7 +2,6 @@ name: Bump Patch Maven version (manual trigger)
 
 permissions:
   contents: write
-  actions: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/bump-patch-version.yml
+++ b/.github/workflows/bump-patch-version.yml
@@ -1,5 +1,9 @@
 name: Bump Patch Maven version (manual trigger)
 
+permissions:
+  contents: write
+  actions: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/FarmVivi/discord-bot/security/code-scanning/4](https://github.com/FarmVivi/discord-bot/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the required permissions. Based on the workflow's actions, the following permissions are necessary:
- `contents: write` to allow the workflow to modify and push changes to the repository.
- `actions: read` to allow the workflow to interact with GitHub Actions.

This ensures that the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
