### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   workflow_dispatch:
+
+jobs:
   bump-minor-version:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -1,9 +1,10 @@
 name: Bump Minor Maven version (manual trigger)
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
-
-jobs:
   bump-minor-version:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/FarmVivi/discord-bot/security/code-scanning/3](https://github.com/FarmVivi/discord-bot/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the operations performed in the workflow, the following permissions are needed:
- `contents: write` to allow the workflow to modify and push changes to the repository.

This ensures that the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
