### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -3,6 +3,9 @@ name: Bump Major Maven version (manual trigger)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   bump-major-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FarmVivi/discord-bot/security/code-scanning/2](https://github.com/FarmVivi/discord-bot/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file to explicitly define the required permissions. Since the workflow involves reading and writing to the repository's contents (e.g., modifying `pom.xml` and pushing changes), we will set `contents: write`. This ensures the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
