### PR TITLE
Fix plugin internationalization system

### DIFF
--- a/fluxcord-api/src/main/java/fr/farmvivi/fluxcord/api/language/PluginLanguageAdapter.java
+++ b/fluxcord-api/src/main/java/fr/farmvivi/fluxcord/api/language/PluginLanguageAdapter.java
@@ -25,7 +25,7 @@ public class PluginLanguageAdapter {
     public PluginLanguageAdapter(Plugin plugin, LanguageManager languageManager) {
         this.plugin = plugin;
         this.languageManager = languageManager;
-        this.namespace = plugin.getName().toLowerCase();
+        this.namespace = plugin.getId();
 
         // Register the namespace automatically
         boolean registered = languageManager.registerNamespace(namespace);

--- a/fluxcord-api/src/main/java/fr/farmvivi/fluxcord/api/storage/PluginDataStorageAdapter.java
+++ b/fluxcord-api/src/main/java/fr/farmvivi/fluxcord/api/storage/PluginDataStorageAdapter.java
@@ -20,7 +20,7 @@ public class PluginDataStorageAdapter {
     public PluginDataStorageAdapter(Plugin plugin, DataStorageManager storageManager) {
         this.plugin = plugin;
         this.storageManager = storageManager;
-        this.namespace = plugin.getName().toLowerCase();
+        this.namespace = plugin.getId();
     }
 
     /**

--- a/fluxcord-api/src/main/java/fr/farmvivi/fluxcord/api/storage/binary/PluginBinaryStorageAdapter.java
+++ b/fluxcord-api/src/main/java/fr/farmvivi/fluxcord/api/storage/binary/PluginBinaryStorageAdapter.java
@@ -20,7 +20,7 @@ public class PluginBinaryStorageAdapter {
     public PluginBinaryStorageAdapter(Plugin plugin, BinaryStorageManager storageManager) {
         this.plugin = plugin;
         this.storageManager = storageManager;
-        this.namespace = plugin.getName().toLowerCase();
+        this.namespace = plugin.getId();
     }
 
     /**

--- a/plugin-template/src/main/java/com/example/plugin/TemplatePlugin.java
+++ b/plugin-template/src/main/java/com/example/plugin/TemplatePlugin.java
@@ -369,7 +369,7 @@ public class TemplatePlugin extends AbstractPlugin {
      * @return the full permission name with plugin prefix
      */
     private String pluginPrefix(String node) {
-        return getName().toLowerCase() + "." + node;
+        return getId() + "." + node;
     }
 
     // Simple internal Permission implementation for template usage

--- a/plugins/ai-audio-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/aiaudio/AIAudioPlugin.java
+++ b/plugins/ai-audio-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/aiaudio/AIAudioPlugin.java
@@ -71,7 +71,7 @@ public class AIAudioPlugin extends AbstractPlugin {
     }
 
     private String permissionKey(String node) {
-        return getName().toLowerCase() + "." + node;
+        return getId() + "." + node;
     }
 
     private void initializeServices() {

--- a/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/ButtonHandler.java
+++ b/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/ButtonHandler.java
@@ -187,7 +187,7 @@ public class ButtonHandler {
         String userId = member.getId();
         String guildId = member.getGuild().getId();
         // Permission nodes are registered as pluginName.node
-        String perm = plugin.getName().toLowerCase() + "." + permission.substring(permission.indexOf('.') + 1);
+        String perm = plugin.getId() + "." + permission.substring(permission.indexOf('.') + 1);
         return plugin.getPluginPermissionManager().hasPermission(userId, guildId, perm)
                 || plugin.getPluginPermissionManager().hasPermission(userId, perm);
     }

--- a/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/MusicPlugin.java
+++ b/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/MusicPlugin.java
@@ -105,7 +105,7 @@ public class MusicPlugin extends AbstractPlugin {
     }
 
     private String permissionKey(String node) {
-        return getName().toLowerCase() + "." + node;
+        return getId() + "." + node;
     }
 
     private void registerCommands() {

--- a/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/commands/PlayCommand.java
+++ b/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/commands/PlayCommand.java
@@ -43,7 +43,7 @@ public class PlayCommand {
 
         // Check permission (prefer guild-scoped if available)
         String userId = ctx.getUser().getId();
-        String perm = plugin.getName().toLowerCase() + ".play";
+        String perm = plugin.getId() + ".play";
         boolean allowed = plugin.getPluginPermissionManager().hasPermission(userId, guild.getId(), perm)
                 || plugin.getPluginPermissionManager().hasPermission(userId, perm);
         if (!allowed) {

--- a/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/commands/SkipCommand.java
+++ b/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/commands/SkipCommand.java
@@ -35,7 +35,7 @@ public class SkipCommand {
 
         // Check permission
         String userId = ctx.getUser().getId();
-        String perm = plugin.getName().toLowerCase() + ".skip";
+        String perm = plugin.getId() + ".skip";
         boolean allowed = plugin.getPluginPermissionManager().hasPermission(userId, guild.getId(), perm)
                 || plugin.getPluginPermissionManager().hasPermission(userId, perm);
         if (!allowed) {

--- a/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/commands/VolumeCommand.java
+++ b/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/commands/VolumeCommand.java
@@ -29,7 +29,7 @@ public class VolumeCommand {
 
         // Check permission
         String userId = ctx.getUser().getId();
-        String perm = plugin.getName().toLowerCase() + ".volume";
+        String perm = plugin.getId() + ".volume";
         boolean allowed = plugin.getPluginPermissionManager().hasPermission(userId, guild.getId(), perm)
                 || plugin.getPluginPermissionManager().hasPermission(userId, perm);
         if (!allowed) {


### PR DESCRIPTION
Update internationalization and permission systems to use plugin IDs instead of plugin names for namespaces and prefixes.

The previous implementation used `plugin.getName().toLowerCase()` for generating namespaces in language/storage adapters and for permission prefixes in plugins. This caused incorrect translation key lookups and malformed permission nodes after the introduction of explicit plugin IDs, preventing proper internationalization and permission checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fa3f09a-490c-4e79-8dca-7b6039585b15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5fa3f09a-490c-4e79-8dca-7b6039585b15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

