### PR TITLE
Fix music queue bug in loop mode

### DIFF
--- a/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/player/TrackScheduler.java
+++ b/plugins/music-plugin/src/main/java/fr/farmvivi/fluxcord/plugins/music/player/TrackScheduler.java
@@ -91,7 +91,8 @@ public class TrackScheduler extends AudioEventAdapter {
         } else {
             next = queue.poll();
             if (next != null) {
-                queueList.remove(next);
+                // Remove the first occurrence from queueList
+                queueList.remove(0);
             }
         }
 
@@ -110,6 +111,8 @@ public class TrackScheduler extends AudioEventAdapter {
     public void skip() {
         AudioTrack current = player.getPlayingTrack();
         if (current != null && loopMode) {
+            // En mode loop, on ajoute la piste actuelle à la fin de la queue
+            // pour qu'elle soit rejouée plus tard, pas immédiatement
             addToQueueEnd(current.makeClone());
         }
         nextTrack();


### PR DESCRIPTION
Correctly remove the current track from the queue list to ensure proper loop mode functionality when skipping tracks.

The previous implementation of `queueList.remove(next)` failed in loop mode because `next` was the original track object, while `addToQueueEnd()` added a clone. This caused `remove` to fail due to object equality, leading to incorrect queue management. Changing to `queueList.remove(0)` ensures the first element, which `queue.poll()` has already processed, is consistently removed from `queueList`.

---
<a href="https://cursor.com/background-agent?bcId=bc-97f8bd6e-71e7-4950-aeee-0b9913622e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97f8bd6e-71e7-4950-aeee-0b9913622e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

