### PR TITLE
Build docker image with platform error

### DIFF
--- a/Dockerfile.buildkit.multiplatform
+++ b/Dockerfile.buildkit.multiplatform
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 ################ Build ################
 # Build stage for the full multi-module project
-FROM --platform=linux/amd64 maven:3.9.11-eclipse-temurin-17-alpine AS build
+# Using maven:3.9-openjdk-17-slim which has better multi-platform support
+FROM maven:3.9-openjdk-17-slim AS build
 
 WORKDIR /workspace
 
@@ -37,7 +38,8 @@ RUN --mount=type=cache,target=/root/.m2/repository \
 
 ################ Production ################
 # Use a small JRE base with shell to run an entrypoint script
-FROM --platform=linux/amd64 eclipse-temurin:17.0.16_8-jre-alpine-3.22 AS production
+# Using eclipse-temurin:17-jre which has better multi-platform support
+FROM eclipse-temurin:17-jre AS production
 
 ENV APP_DIR=/app \
     BUNDLES_DIR=/opt/fluxcord/bundles \
@@ -46,7 +48,7 @@ ENV APP_DIR=/app \
 WORKDIR /app
 
 # Install curl for healthcheck
-RUN apk add --no-cache curl
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 ## Core shaded jar
 COPY --from=build /workspace/.artifacts/fluxcord.jar /app/fluxcord.jar


### PR DESCRIPTION
Explicitly specify `linux/amd64` in `Dockerfile.buildkit` and introduce `Dockerfile.buildkit.multiplatform` to address "no match for platform" errors.

The original build failed on ARM64 due to the `maven:3.9.11-eclipse-temurin-17-alpine` image lacking an `arm64` manifest. The `Dockerfile.buildkit` update forces `amd64` for a quick fix, while `Dockerfile.buildkit.multiplatform` offers a robust solution using base images with native multi-platform support.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef240a54-6109-4c57-b340-07b9de631045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef240a54-6109-4c57-b340-07b9de631045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

